### PR TITLE
3049 add demo api access coingecko

### DIFF
--- a/packages/plugin-coingecko/src/actions/getMarkets.ts
+++ b/packages/plugin-coingecko/src/actions/getMarkets.ts
@@ -134,7 +134,7 @@ export default {
 
         try {
             const config = await validateCoingeckoConfig(runtime);
-            const { baseUrl, apiKey } = getApiConfig(config);
+            const { baseUrl, apiKey, headerKey } = getApiConfig(config);
 
             // Get categories through the provider
             const categories = await getCategoriesData(runtime);
@@ -186,7 +186,7 @@ export default {
                 {
                     headers: {
                         'accept': 'application/json',
-                        'x-cg-pro-api-key': apiKey
+                        [headerKey]: apiKey
                     },
                     params: {
                         vs_currency: content.vs_currency,

--- a/packages/plugin-coingecko/src/actions/getPrice.ts
+++ b/packages/plugin-coingecko/src/actions/getPrice.ts
@@ -120,7 +120,7 @@ export default {
 
             // Fetch price from CoinGecko
             const config = await validateCoingeckoConfig(runtime);
-            const { baseUrl, apiKey } = getApiConfig(config);
+            const { baseUrl, apiKey, headerKey } = getApiConfig(config);
 
             elizaLogger.log(`Fetching prices for ${coinIds} in ${vs_currencies}...`);
             elizaLogger.log("API request URL:", `${baseUrl}/simple/price`);
@@ -146,7 +146,7 @@ export default {
                     },
                     headers: {
                         'accept': 'application/json',
-                        'x-cg-pro-api-key': apiKey
+                        [headerKey]: apiKey
                     }
                 }
             );


### PR DESCRIPTION
# Relates to

[<!-- LINK TO ISSUE OR TICKET -->](https://github.com/elizaOS/eliza/issues/3049)



# Risks

Low: Coingecko might revoke demo access to these two api endpoints. Then, these two actions would break for users with only a demo api key. 

# Background

## What does this PR do?

Add demo api access to coingecko plugin 

I would like to be able to use a demo key for these two actions in the coingecko plugin: GET_MARKETS and GET_PRICE.
The coingecko plugin defaults to using coingecko's pro api for these two actions, even though both endpoints are also available to demo users.
GET_TRENDING and GET_TOP_GAINERS_LOSERS already check for api configuration, and can use coingecko's demo endpoint.

## What kind of change is this?

Improvements (misc. changes to existing features)



